### PR TITLE
Changed dep url to fetch without a registered ssh key

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "git@github.com:zcoinofficial/bitcore-message-zcoin.git"
   },
   "dependencies": {
-    "zcore-lib": "git+ssh://git@github.com:zcoinofficial/zcore-lib.git"
+    "zcore-lib": "git://github.com/zcoinofficial/zcore-lib.git"
   },
   "devDependencies": {
     "bitcore-build": "bitpay/bitcore-build",


### PR DESCRIPTION
with this change there is no need for a registered ssh key in a github account to fetch this dependency which provides easier deployment in a docker environment.